### PR TITLE
Feat: support cluster control plane label

### DIFF
--- a/pkg/apis/cluster/v1alpha1/config.go
+++ b/pkg/apis/cluster/v1alpha1/config.go
@@ -36,6 +36,9 @@ const (
 var (
 	// AnnotationClusterAlias the annotation key for cluster alias
 	AnnotationClusterAlias = config.MetaApiGroupName + "/cluster-alias"
+
+	// LabelClusterControlPlane identifies whether the cluster is the control plane
+	LabelClusterControlPlane = config.MetaApiGroupName + "/control-plane"
 )
 
 // StorageNamespace refers to the namespace of cluster secret, usually same as the core kubevela system namespace

--- a/pkg/apis/cluster/v1alpha1/reader.go
+++ b/pkg/apis/cluster/v1alpha1/reader.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	clustergatewayv1alpha1 "github.com/oam-dev/cluster-gateway/pkg/apis/cluster/v1alpha1"
@@ -67,6 +68,7 @@ func newCluster(obj client.Object) *Cluster {
 	}
 	cluster.Spec.Accepted = true
 	cluster.Spec.Endpoint = ClusterBlankEndpoint
+	metav1.SetMetaDataLabel(&cluster.ObjectMeta, LabelClusterControlPlane, fmt.Sprintf("%t", obj == nil))
 	return cluster
 }
 

--- a/pkg/apis/cluster/v1alpha1/types_test.go
+++ b/pkg/apis/cluster/v1alpha1/types_test.go
@@ -169,6 +169,27 @@ var _ = Describe("Test Cluster API", func() {
 		Expect(clusters.Items[0].Name).To(Equal("ocm-cluster"))
 		Expect(clusters.Items[1].Name).To(Equal("test-cluster"))
 
+		By("Test list clusters that are not control plane")
+		objs, err = c.List(ctx, &metainternalversion.ListOptions{LabelSelector: labels.SelectorFromSet(map[string]string{
+			LabelClusterControlPlane: "false",
+		})})
+		Ω(err).To(Succeed())
+		clusters, ok = objs.(*ClusterList)
+		Ω(ok).To(BeTrue())
+		Expect(len(clusters.Items)).To(Equal(2))
+		Expect(clusters.Items[0].Name).To(Equal("ocm-cluster"))
+		Expect(clusters.Items[1].Name).To(Equal("test-cluster"))
+
+		By("Test list clusters that is control plane")
+		objs, err = c.List(ctx, &metainternalversion.ListOptions{LabelSelector: labels.SelectorFromSet(map[string]string{
+			LabelClusterControlPlane: "true",
+		})})
+		Ω(err).To(Succeed())
+		clusters, ok = objs.(*ClusterList)
+		Ω(ok).To(BeTrue())
+		Expect(len(clusters.Items)).To(Equal(1))
+		Expect(clusters.Items[0].Name).To(Equal("local"))
+
 		By("Test print table")
 		_, err = c.ConvertToTable(ctx, cluster, nil)
 		Ω(err).To(Succeed())


### PR DESCRIPTION
Signed-off-by: Yin Da <yd219913@alibaba-inc.com>

Support `cluster.core.oam.dev/control-plane` label for all clusters. This label is added in logic label, but can be seen and selected.