### PR TITLE
Feat: add request timeout options

### DIFF
--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -26,6 +26,7 @@ import (
 	grafanav1alpha1 "github.com/kubevela/prism/pkg/apis/o11y/grafana/v1alpha1"
 	grafanadashboardv1alpha1 "github.com/kubevela/prism/pkg/apis/o11y/grafanadashboard/v1alpha1"
 	grafanadatasourcev1alpha1 "github.com/kubevela/prism/pkg/apis/o11y/grafanadatasource/v1alpha1"
+	apiserveroptions "github.com/kubevela/prism/pkg/util/apiserver/options"
 	"github.com/kubevela/prism/pkg/util/log"
 	"github.com/kubevela/prism/pkg/util/singleton"
 )
@@ -41,12 +42,14 @@ func main() {
 		WithResource(&grafanav1alpha1.Grafana{}).
 		WithResource(&grafanadatasourcev1alpha1.GrafanaDatasource{}).
 		WithResource(&grafanadashboardv1alpha1.GrafanaDashboard{}).
+		WithConfigFns(apiserveroptions.WrapConfig).
 		WithPostStartHook("init-master-loopback-client", singleton.InitLoopbackClient).
 		Build()
 	if err != nil {
 		klog.Fatal(err)
 	}
 	log.AddLogFlags(cmd)
+	apiserveroptions.AddServerRunFlags(cmd.Flags())
 	clusterv1alpha1.AddClusterFlags(cmd.Flags())
 	o11yconfig.AddObservabilityFlags(cmd.Flags())
 	if err = cmd.Execute(); err != nil {

--- a/pkg/util/apiserver/options/server_run_options.go
+++ b/pkg/util/apiserver/options/server_run_options.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"time"
+
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apiserver/pkg/server"
+)
+
+// ServerRunOptions is the extension option for configuring the APIServer
+type ServerRunOptions struct {
+	RequestTimeout time.Duration
+}
+
+func NewServerRunOptions() *ServerRunOptions {
+	defaults := server.NewConfig(serializer.CodecFactory{})
+	return &ServerRunOptions{
+		RequestTimeout: defaults.RequestTimeout,
+	}
+}
+
+// ApplyTo set the params in server.RecommendConfig
+func (s *ServerRunOptions) ApplyTo(c *server.Config) error {
+	c.RequestTimeout = s.RequestTimeout
+	return nil
+}
+
+// AddFlags add flags for a specific APIServer to the specified FlagSet
+func (s *ServerRunOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.DurationVar(&s.RequestTimeout, "request-timeout", s.RequestTimeout, ""+
+		"An optional field indicating the duration a handler must keep a request open before timing "+
+		"it out. This is the default request timeout for requests but may be overridden by flags such as "+
+		"--min-request-timeout for specific types of requests.")
+}
+
+var defaultServerRunOptions = NewServerRunOptions()
+
+// WrapConfig wraps server.RecommendedConfig with default ServerRunOptions
+func WrapConfig(config *server.RecommendedConfig) *server.RecommendedConfig {
+	runtime.Must(defaultServerRunOptions.ApplyTo(&config.Config))
+	return config
+}
+
+// AddServerRunFlags add ServerRunOptions flags to pflag.FlagSet
+func AddServerRunFlags(fs *pflag.FlagSet) {
+	defaultServerRunOptions.AddFlags(fs)
+}

--- a/pkg/util/apiserver/options/server_run_options_test.go
+++ b/pkg/util/apiserver/options/server_run_options_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apiserver/pkg/server"
+)
+
+func TestServerRunOptions(t *testing.T) {
+	cfg := &server.RecommendedConfig{}
+	AddServerRunFlags(pflag.CommandLine)
+	defaultServerRunOptions.RequestTimeout = time.Second * 10
+	WrapConfig(cfg)
+	require.Equal(t, cfg.RequestTimeout, time.Second*10)
+}


### PR DESCRIPTION
Signed-off-by: Yin Da <yd219913@alibaba-inc.com>

Example: setting `--request-timeout=5s` will enforce a timeout of 5s for each resource API call.