### PR TITLE
Feat: support cue exec engine

### DIFF
--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -26,7 +26,7 @@ import (
 	grafanav1alpha1 "github.com/kubevela/prism/pkg/apis/o11y/grafana/v1alpha1"
 	grafanadashboardv1alpha1 "github.com/kubevela/prism/pkg/apis/o11y/grafanadashboard/v1alpha1"
 	grafanadatasourcev1alpha1 "github.com/kubevela/prism/pkg/apis/o11y/grafanadatasource/v1alpha1"
-	"github.com/kubevela/prism/pkg/cue"
+	cueserver "github.com/kubevela/prism/pkg/cue/server"
 	apiserver "github.com/kubevela/prism/pkg/dynamicapiserver"
 	apiserveroptions "github.com/kubevela/prism/pkg/util/apiserver/options"
 	"github.com/kubevela/prism/pkg/util/log"
@@ -45,7 +45,7 @@ func main() {
 		WithResource(&grafanadatasourcev1alpha1.GrafanaDatasource{}).
 		WithResource(&grafanadashboardv1alpha1.GrafanaDashboard{}).
 		WithConfigFns(apiserveroptions.WrapConfig, singleton.InitServerConfig).
-		WithServerFns(cue.RegisterGenericAPIServer, singleton.InitGenericAPIServer).
+		WithServerFns(cueserver.RegisterGenericAPIServer, singleton.InitGenericAPIServer).
 		WithPostStartHook("start-dynamic-server", apiserver.StartDefaultDynamicAPIServer).
 		Build()
 	runtime.Must(err)

--- a/pkg/cue/engine/compile.go
+++ b/pkg/cue/engine/compile.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"context"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/build"
+	"cuelang.org/go/cue/cuecontext"
+	"cuelang.org/go/cue/parser"
+
+	"github.com/kubevela/prism/pkg/cue/providers"
+	"github.com/kubevela/prism/pkg/cue/providers/http"
+)
+
+type CompileOption interface {
+	ApplyTo(*CompileConfig)
+}
+
+type CompileConfig struct {
+	Imports []*build.Instance
+	providers.Providers
+}
+
+var DefaultProviders = providers.NewProviders()
+
+func init() {
+	DefaultProviders.Register(http.Package)
+}
+
+func NewCompileConfig() *CompileConfig {
+	return &CompileConfig{
+		Imports:   []*build.Instance{},
+		Providers: DefaultProviders,
+	}
+}
+
+type WithImports []*build.Instance
+
+func (op WithImports) ApplyTo(cfg *CompileConfig) {
+	cfg.Imports = append(cfg.Imports, op...)
+}
+
+type WithoutProviders struct{}
+
+func (op WithoutProviders) ApplyTo(cfg *CompileConfig) { cfg.Providers = nil }
+
+type WithProviders struct {
+	providers.Providers
+}
+
+func (op WithProviders) ApplyTo(cfg *CompileConfig) { cfg.Providers = op }
+
+func Compile(ctx context.Context, src string, opts ...CompileOption) (cue.Value, error) {
+	cfg := NewCompileConfig()
+	for _, op := range opts {
+		op.ApplyTo(cfg)
+	}
+	bi := build.NewContext().NewInstance("", nil)
+	bi.Imports = cfg.Imports
+	if cfg.Providers != nil {
+		bi.Imports = append(bi.Imports, cfg.Providers.Imports()...)
+	}
+	f, err := parser.ParseFile("-", src)
+	if err != nil {
+		return cue.Value{}, err
+	}
+	if err = bi.AddSyntax(f); err != nil {
+		return cue.Value{}, err
+	}
+	val := cuecontext.New().BuildInstance(bi)
+	if cfg.Providers != nil {
+		val, err = cfg.Providers.Complete(ctx, val)
+	}
+	return val, err
+}

--- a/pkg/cue/engine/compile_test.go
+++ b/pkg/cue/engine/compile_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"cuelang.org/go/cue"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubevela/prism/pkg/cue/engine"
+	"github.com/kubevela/prism/pkg/cue/providers"
+)
+
+func TestCompile(t *testing.T) {
+	x := `
+	import "vela/http"
+	x: http.#Do & {
+		url: "https://api64.ipify.org/"
+		method: "GET"
+	}`
+	v, err := engine.Compile(context.Background(), x)
+	require.NoError(t, err)
+	i, err := v.LookupPath(cue.ParsePath("x.response.statusCode")).Int64()
+	require.NoError(t, err)
+	require.Equal(t, int64(200), i)
+
+	x = `
+	x: {
+		#do: "unknown"
+		#provider: "none"
+	}
+	`
+	v, err = engine.Compile(context.Background(), x)
+	require.ErrorContains(t, err, "provider none not found")
+
+	x = `
+	import "vela/http"
+	x: {
+		#do: "unknown"
+		#provider: "http"
+	}
+	`
+	v, err = engine.Compile(context.Background(), x)
+	require.ErrorContains(t, err, "function unknown not found in provider http")
+}
+
+func TestCompileWithoutProviders(t *testing.T) {
+	x := `
+	x: "src/"
+	y: z: x + "test"`
+	v, err := engine.Compile(context.Background(), x, engine.WithoutProviders{})
+	require.NoError(t, err)
+	i, err := v.LookupPath(cue.ParsePath("y.z")).String()
+	require.NoError(t, err)
+	require.Equal(t, "src/test", i)
+}
+
+type TestParams struct {
+	Key string `json:"key"`
+}
+
+type TestReturns struct {
+	Value string `json:"value"`
+}
+
+func test(ctx context.Context, params *TestParams) (*TestReturns, error) {
+	if params.Key == "" {
+		return nil, fmt.Errorf("empty key")
+	}
+	return &TestReturns{Value: "key: " + params.Key}, nil
+}
+
+func TestCompileWithCustomizedProvider(t *testing.T) {
+	prds := engine.DefaultProviders.DeepCopy()
+	pkg, err := providers.NewPackage(
+		"custom",
+		`
+			package custom
+			#Test: {
+				#do: "test"
+				#provider: "custom"
+				key: string
+				value?: string
+			}
+		`,
+		map[string]providers.ProviderFn{
+			"test": providers.GenericProviderFn[TestParams, TestReturns](test),
+		})
+	require.NoError(t, err)
+	prds.Register(pkg)
+	x := `
+	import "vela/custom"
+	x: y: custom.#Test & {
+		key: "k"
+	}`
+	v, err := engine.Compile(context.Background(), x, engine.WithProviders{Providers: prds})
+	require.NoError(t, err)
+	i, err := v.LookupPath(cue.ParsePath("x.y.value")).String()
+	require.NoError(t, err)
+	require.Equal(t, "key: k", i)
+
+	x = `
+	import "vela/custom"
+	x: y: custom.#Test & {
+		key: ""
+	}`
+	_, err = engine.Compile(context.Background(), x, engine.WithProviders{Providers: prds})
+	require.ErrorContains(t, err, "empty key")
+}

--- a/pkg/cue/providers/error.go
+++ b/pkg/cue/providers/error.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providers
+
+import (
+	"fmt"
+
+	"cuelang.org/go/cue"
+
+	"github.com/kubevela/prism/pkg/cue/util"
+)
+
+type ProviderNotFoundErr string
+
+func (e ProviderNotFoundErr) Error() string {
+	return fmt.Sprintf("provider %s not found", string(e))
+}
+
+type ProviderFnNotFoundErr struct {
+	Provider, Fn string
+}
+
+func (e ProviderFnNotFoundErr) Error() string {
+	return fmt.Sprintf("function %s not found in provider %s", e.Fn, e.Provider)
+}
+
+type ExecuteError struct {
+	Path  string
+	Value string
+	Err   error
+}
+
+func (e ExecuteError) Error() string {
+	return fmt.Sprintf("execute error for %s: %s (value: %s)", e.Path, e.Err.Error(), e.Value)
+}
+
+func NewExecuteError(v cue.Value, err error) ExecuteError {
+	path := v.Path().String()
+	s, e := util.ToString(v)
+	if e != nil {
+		s = e.Error()
+	}
+	return ExecuteError{Path: path, Value: s, Err: err}
+}

--- a/pkg/cue/providers/http/http.cue
+++ b/pkg/cue/providers/http/http.cue
@@ -1,0 +1,43 @@
+package http
+
+#Do: {
+	#do: "do"
+	#provider: "http"
+
+	// +usage=The method of HTTP request
+	method: *"GET" | "POST" | "PUT" | "DELETE"
+	// +usage=The url to request
+	url: string
+	// +usage=The request config
+	request?: {
+		// +usage=The timeout of this request
+		timeout?: string
+		// +usage=The request body
+		body?: string
+		// +usage=The header of the request
+		header?: [string]: string
+		// +usage=The trailer of the request
+		trailer?: [string]: string
+		// +usage=The rate limiter of the request
+		ratelimiter?: {
+			limit:  int
+			period: string
+		}
+		...
+	}
+	// +usgae=The tls config of the request
+	tls_config?: secret: string
+	// +usage=The response of the request will be filled in this field after the action is executed
+	response?: {
+		// +usage=The body of the response
+		body?: string
+		// +usage=The header of the response
+		header?: [string]: [...string]
+		// +usage=The trailer of the response
+		trailer?: [string]: [...string]
+		// +usage=The status code of the response
+		statusCode: int
+		...
+	}
+	...
+}

--- a/pkg/cue/providers/http/http.go
+++ b/pkg/cue/providers/http/http.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"context"
+	_ "embed"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/kubevela/prism/pkg/cue/providers"
+	"github.com/kubevela/prism/pkg/util/runtime"
+)
+
+type DoParams struct {
+	Method  string `json:"method"`
+	URL     string `json:"url"`
+	Request struct {
+		Body string `json:"body"`
+	} `json:"request"`
+	Header  http.Header `json:"header"`
+	Trailer http.Header `json:"trailer"`
+}
+
+type DoReturns struct {
+	Response struct {
+		Body       string      `json:"body"`
+		Header     http.Header `json:"header"`
+		Trailer    http.Header `json:"trailer"`
+		StatusCode int         `json:"statusCode"`
+	} `json:"response"`
+}
+
+func Do(ctx context.Context, params *DoParams) (*DoReturns, error) {
+	req, err := http.NewRequestWithContext(ctx, params.Method, params.URL, strings.NewReader(params.Request.Body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header = params.Header
+	req.Trailer = params.Trailer
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	// parse response body and headers
+	ret := &DoReturns{}
+	ret.Response.Body = string(b)
+	ret.Response.Header = resp.Header
+	ret.Response.Trailer = resp.Trailer
+	ret.Response.StatusCode = resp.StatusCode
+	return ret, nil
+}
+
+const ProviderName = "http"
+
+//go:embed http.cue
+var template string
+
+var Package = runtime.Must(providers.NewPackage(ProviderName, template, map[string]providers.ProviderFn{
+	"do": providers.GenericProviderFn[DoParams, DoReturns](Do),
+}))

--- a/pkg/cue/providers/http/http_test.go
+++ b/pkg/cue/providers/http/http_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubevela/prism/pkg/cue/providers/http"
+)
+
+func TestDo(t *testing.T) {
+	ret, err := http.Do(context.Background(), &http.DoParams{
+		Method: "GET", URL: "https://api64.ipify.org/",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 200, ret.Response.StatusCode)
+}

--- a/pkg/cue/providers/package.go
+++ b/pkg/cue/providers/package.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providers
+
+import (
+	"cuelang.org/go/cue/build"
+
+	"github.com/kubevela/prism/pkg/cue/util"
+)
+
+const (
+	VelaPrefix = "vela/"
+)
+
+type Package struct {
+	Name string
+	Fns  map[string]ProviderFn
+
+	Template string
+	Import   *build.Instance
+}
+
+func NewPackage(name string, template string, fns map[string]ProviderFn) (*Package, error) {
+	bi, err := util.BuildImport(VelaPrefix+name, template)
+	if err != nil {
+		return nil, err
+	}
+	return &Package{
+		Name:     name,
+		Fns:      fns,
+		Template: template,
+		Import:   bi,
+	}, nil
+}

--- a/pkg/cue/providers/providers.go
+++ b/pkg/cue/providers/providers.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/build"
+
+	"github.com/kubevela/prism/pkg/cue/util"
+)
+
+const (
+	doKey       = "#do"
+	providerKey = "#provider"
+)
+
+type ProviderFn interface {
+	Call(context.Context, cue.Value) (cue.Value, error)
+}
+
+type GenericProviderFn[T any, U any] func(context.Context, *T) (*U, error)
+
+func (fn GenericProviderFn[T, U]) Call(ctx context.Context, value cue.Value) (cue.Value, error) {
+	params := new(T)
+	bs, err := value.MarshalJSON()
+	if err != nil {
+		return value, err
+	}
+	if err = json.Unmarshal(bs, params); err != nil {
+		return value, err
+	}
+	ret, err := fn(ctx, params)
+	if err != nil {
+		return value, err
+	}
+	return value.FillPath(cue.ParsePath(""), ret), nil
+}
+
+type Providers interface {
+	GetProviderFn(provider string, fn string) (ProviderFn, error)
+	Register(pkg *Package)
+	Complete(ctx context.Context, value cue.Value) (cue.Value, error)
+	Imports() []*build.Instance
+	DeepCopy() Providers
+}
+
+func NewProviders() Providers {
+	return &providers{
+		m: map[string]*Package{},
+	}
+}
+
+type providers struct {
+	mu sync.RWMutex
+	m  map[string]*Package
+}
+
+func (p *providers) GetProviderFn(provider string, fn string) (ProviderFn, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	prd, ok := p.m[provider]
+	if !ok {
+		return nil, ProviderNotFoundErr(provider)
+	}
+	f, ok := prd.Fns[fn]
+	if !ok {
+		return nil, ProviderFnNotFoundErr{Provider: provider, Fn: fn}
+	}
+	return f, nil
+}
+
+func (p *providers) Register(pkg *Package) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.m[pkg.Name] = pkg
+}
+
+func (p *providers) Complete(ctx context.Context, value cue.Value) (cue.Value, error) {
+	newValue := value
+	executed := map[string]bool{}
+	for {
+		var next *cue.Value
+		// 1. find the next to execute
+		util.Iterate(newValue, func(v cue.Value) (stop bool) {
+			_, done := executed[v.Path().String()]
+			fn, _ := v.LookupPath(cue.ParsePath(doKey)).String()
+			if !done && fn != "" {
+				next = &v
+				return true
+			}
+			return false
+		})
+		if next == nil {
+			break
+		}
+		// 2. execute
+		fn, _ := next.LookupPath(cue.ParsePath(doKey)).String()
+		prd, _ := next.LookupPath(cue.ParsePath(providerKey)).String()
+		f, err := p.GetProviderFn(prd, fn)
+		if err != nil {
+			return newValue, err
+		}
+		val, err := f.Call(ctx, *next)
+		if err != nil {
+			return newValue, NewExecuteError(val, err)
+		}
+		newValue = newValue.FillPath(next.Path(), val)
+		executed[next.Path().String()] = true
+	}
+	return newValue, nil
+}
+
+func (p *providers) Imports() []*build.Instance {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	var imports []*build.Instance
+	for _, v := range p.m {
+		if v.Import != nil {
+			imports = append(imports, v.Import)
+		}
+	}
+	return imports
+}
+
+func (p *providers) DeepCopy() Providers {
+	newp := &providers{m: map[string]*Package{}}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for k, v := range p.m {
+		newp.m[k] = v
+	}
+	return newp
+}

--- a/pkg/cue/server/render.go
+++ b/pkg/cue/server/render.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
+
+	"github.com/kubevela/prism/pkg/cue/engine"
+)
+
+func Render(bs []byte, path ...string) ([]byte, error) {
+	ctx := cuecontext.New()
+	val := ctx.CompileBytes(bs)
+	if err := val.Err(); err != nil {
+		return nil, err
+	}
+	for _, p := range path {
+		val = val.LookupPath(cue.ParsePath(p))
+	}
+	return val.MarshalJSON()
+}
+
+// Compile cue bytes and get the json output for the given path
+func Compile(bs []byte, path ...string) ([]byte, error) {
+	val, err := engine.Compile(context.Background(), string(bs))
+	if err != nil {
+		return nil, err
+	}
+	if err = val.Err(); err != nil {
+		return nil, err
+	}
+	for _, p := range path {
+		val = val.LookupPath(cue.ParsePath(p))
+	}
+	return val.MarshalJSON()
+}

--- a/pkg/cue/server/render_test.go
+++ b/pkg/cue/server/render_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	cueserver "github.com/kubevela/prism/pkg/cue/server"
+)
+
+func TestCompileBytes(t *testing.T) {
+	bad := []byte(`something-bad: bad-value`)
+	_, err := cueserver.Render(bad)
+	require.Error(t, err)
+	good := []byte(`
+	x: *3 | int
+	y: pow: x * x
+	z: yVal: pow: y.pow 
+	`)
+	bs, err := cueserver.Render(good, "z", "yVal")
+	require.NoError(t, err)
+	require.Equal(t, []byte(`{"pow":9}`), bs)
+}

--- a/pkg/cue/server/webservice.go
+++ b/pkg/cue/server/webservice.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cue
+package server
 
 import (
 	"io"
@@ -25,9 +25,10 @@ import (
 )
 
 const (
-	webserviceRootPath         = "/cue"
-	webserviceEvalPath         = "/eval"
-	webserviceParameterKeyPath = "path"
+	webserviceRootPath            = "/cue"
+	webserviceEvalPath            = "/eval"
+	webserviceParameterKeyPath    = "path"
+	webserviceParameterKeyCompile = "compile"
 )
 
 func RegisterGenericAPIServer(server *server.GenericAPIServer) *server.GenericAPIServer {
@@ -48,7 +49,11 @@ func HandleEvalRequest(request *restful.Request, response *restful.Response) {
 	if p := request.QueryParameter(webserviceParameterKeyPath); len(p) > 0 {
 		path = append(path, p)
 	}
-	res, err := CompileBytes(bs, path...)
+	f := Render
+	if p := request.QueryParameter(webserviceParameterKeyCompile); len(p) > 0 {
+		f = Compile
+	}
+	res, err := f(bs, path...)
 	if err != nil {
 		_ = response.WriteError(http.StatusBadRequest, err)
 		return

--- a/pkg/cue/server/webservice_test.go
+++ b/pkg/cue/server/webservice_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cue_test
+package server_test
 
 import (
 	"bytes"
@@ -26,14 +26,14 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apiserver/pkg/server"
 
-	"github.com/kubevela/prism/pkg/cue"
+	cueserver "github.com/kubevela/prism/pkg/cue/server"
 )
 
 func TestRegisterGenericAPIServer(t *testing.T) {
 	s := &server.GenericAPIServer{Handler: &server.APIServerHandler{
 		GoRestfulContainer: restful.NewContainer(),
 	}}
-	cue.RegisterGenericAPIServer(s)
+	cueserver.RegisterGenericAPIServer(s)
 }
 
 type FakeResponseWriter struct {
@@ -106,7 +106,7 @@ func TestHandleEvalRequest(t *testing.T) {
 			request := restful.NewRequest(raw)
 			writer := &FakeResponseWriter{Bad: tt.BadWriter}
 			response := restful.NewResponse(writer)
-			cue.HandleEvalRequest(request, response)
+			cueserver.HandleEvalRequest(request, response)
 			require.Equal(t, tt.StatusCode, writer.StatusCode)
 			if tt.StatusCode == http.StatusOK {
 				require.Equal(t, tt.Output, writer.Bytes())

--- a/pkg/cue/util/import.go
+++ b/pkg/cue/util/import.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"path/filepath"
+
+	"cuelang.org/go/cue/build"
+	"cuelang.org/go/cue/parser"
+)
+
+func BuildImport(path string, template string) (*build.Instance, error) {
+	pkg := &build.Instance{
+		PkgName:    filepath.Base(path),
+		ImportPath: path,
+	}
+	file, err := parser.ParseFile("-", template)
+	if err == nil {
+		err = pkg.AddSyntax(file)
+	}
+	return pkg, err
+}

--- a/pkg/cue/util/import_test.go
+++ b/pkg/cue/util/import_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubevela/prism/pkg/cue/util"
+)
+
+func TestImport(t *testing.T) {
+	bi, err := util.BuildImport("vela/test", `#Test: hello: "hello"`)
+	require.NoError(t, err)
+	require.Equal(t, "test", bi.PkgName)
+}

--- a/pkg/cue/util/iterate_test.go
+++ b/pkg/cue/util/iterate_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util_test
+
+import (
+	"testing"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubevela/prism/pkg/cue/util"
+)
+
+func TestIterate(t *testing.T) {
+	value := cuecontext.New().CompileString(`
+	a: ["a", "b", "c"]
+	b: {
+		c: "val"
+		d: "d"
+	}`)
+	var results []string
+	stop := util.Iterate(value, func(v cue.Value) (stop bool) {
+		if s, err := v.String(); err == nil {
+			results = append(results, s)
+			if s == "val" {
+				return true
+			}
+		}
+		return false
+	})
+	require.Equal(t, []string{"a", "b", "c", "val"}, results)
+	require.True(t, stop)
+}

--- a/pkg/cue/util/string.go
+++ b/pkg/cue/util/string.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/format"
+)
+
+// ToString stringify cue.Value with reference resolved
+func ToString(v cue.Value, opts ...cue.Option) (string, error) {
+	opts = append([]cue.Option{cue.Final(), cue.Docs(true), cue.All()}, opts...)
+	node := v.Syntax(opts...)
+	bs, err := format.Node(node)
+	if err != nil {
+		return "", err
+	}
+	return string(bs), nil
+}

--- a/pkg/cue/util/string_test.go
+++ b/pkg/cue/util/string_test.go
@@ -14,21 +14,30 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cue
+package util_test
 
 import (
-	"cuelang.org/go/cue"
+	"testing"
+
 	"cuelang.org/go/cue/cuecontext"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubevela/prism/pkg/cue/util"
 )
 
-func CompileBytes(bs []byte, path ...string) ([]byte, error) {
+func TestToString(t *testing.T) {
 	ctx := cuecontext.New()
-	val := ctx.CompileBytes(bs)
-	if err := val.Err(); err != nil {
-		return nil, err
-	}
-	for _, p := range path {
-		val = val.LookupPath(cue.ParsePath(p))
-	}
-	return val.MarshalJSON()
+	v := ctx.CompileString(`// +usage=x
+x: y
+y: 5
+_z: 1`)
+	s, err := util.ToString(v)
+	require.NoError(t, err)
+	x := `{
+	// +usage=x
+	x:  5
+	y:  5
+	_z: 1
+}`
+	require.Equal(t, x, s)
 }

--- a/pkg/util/runtime/runtime.go
+++ b/pkg/util/runtime/runtime.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import "k8s.io/apimachinery/pkg/util/runtime"
+
+func Must[T any](t T, err error) T {
+	runtime.Must(err)
+	return t
+}


### PR DESCRIPTION
Signed-off-by: Yin Da <yd219913@alibaba-inc.com>

Add support for cue exec engine. This PR only add supports for `http.#Do`

POST `/cue/eval?compile=true` will return the execution result now.
