### PR TITLE
Chore: replace deprecated command with environment file

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Get the vars
         id: vars
         run: |
-          echo ::set-output name=TAG::${GITHUB_REF#refs/tags/}
+          echo "TAG::${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:


### PR DESCRIPTION
## Description

Closes #44 

Update `.github/workflows/chart.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
echo ::set-output name=TAG::${GITHUB_REF#refs/tags/}
```

**TO-BE**

```yaml
echo "TAG::${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
```